### PR TITLE
Fix document compile error on Windows

### DIFF
--- a/doc/make.bat
+++ b/doc/make.bat
@@ -4,7 +4,7 @@ REM Command file for Sphinx documentation
 
 set SPHINXBUILD=sphinx-build
 set BUILDDIR=_build
-set ALLSPHINXOPTS=-d %BUILDDIR%/doctrees %SPHINXOPTS% .
+set ALLSPHINXOPTS=-d %BUILDDIR%/doctrees %SPHINXOPTS% source
 if NOT "%PAPER%" == "" (
 	set ALLSPHINXOPTS=-D latex_paper_size=%PAPER% %ALLSPHINXOPTS%
 )


### PR DESCRIPTION
The documents are not located in the default position, therefore the auto-generate make.bat cannot compile docs on Windows.
