### PR TITLE
Fix loading mydpss under MacOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     package_dir={ '' : 'src' },
 
     # Dependencies
-    install_requires = ['matplotlib', 'numpy', 'scipy', 'easydev'],
+    install_requires = ['matplotlib', 'numpy', 'scipy'],
     data_files = data_files,
     platforms=["Linux"],
     classifiers=["Development Status :: 1 - Planning",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     package_dir={ '' : 'src' },
 
     # Dependencies
-    install_requires = ['matplotlib', 'numpy', 'scipy'],
+    install_requires = ['matplotlib', 'numpy', 'scipy', 'easydev'],
     data_files = data_files,
     platforms=["Linux"],
     classifiers=["Development Status :: 1 - Planning",

--- a/src/spectrum/mtm.py
+++ b/src/spectrum/mtm.py
@@ -21,6 +21,7 @@ import os
 from os.path import join as pj
 from spectrum.tools import nextpow2
 from pylab import semilogy
+from numpy.ctypeslib import load_library
 
 """
 
@@ -39,38 +40,13 @@ Note that on OSX -shared should be replaced by -dynamiclib and sum.so should be 
 
 """
 
+# Import shared mtspec library
 p = os.path.abspath(os.path.dirname(__file__))
-# Import shared mtspec library depending on the platform.
-if platform.system() == 'Windows':
-    try:
-        lib_name = 'mydpss.pyd'
-        mtspeclib = ctypes.cdll.LoadLibrary(pj(p, lib_name))
-    except:
-        # under python 3.X
-        major = sys.version_info.major
-        minor = sys.version_info.minor
-        lib_name = 'mydpss.cpython-{0}{1}m.so'.format(major, minor)
-        mtspeclib = ctypes.cdll.LoadLibrary(pj(p, lib_name))
-elif platform.system() == 'Darwin':
-    try:
-        lib_name = 'mydpss.so'
-        mtspeclib = ctypes.cdll.LoadLibrary(pj(p, lib_name))
-    except:
-        # under python 3.X
-        major = sys.version_info.major
-        minor = sys.version_info.minor
-        lib_name = 'mydpss.cpython-{0}{1}m-darwin.so'.format(major, minor)
-        mtspeclib = ctypes.cdll.LoadLibrary(pj(p, lib_name))
-else:
-    try:
-        lib_name = 'mydpss.so'
-        mtspeclib = ctypes.cdll.LoadLibrary(pj(p, lib_name))
-    except:
-        # under python 3.X
-        major = sys.version_info.major
-        minor = sys.version_info.minor
-        lib_name = 'mydpss.cpython-{0}{1}m.so'.format(major, minor)
-        mtspeclib = ctypes.cdll.LoadLibrary(pj(p, lib_name))
+lib_name = 'mydpss'
+try:
+    mtspeclib = load_library(libname, p)
+except:
+    print("Library %s not found" % lib_name)
 
 
 def pmtm(x, NW=None, k=None, NFFT=None, e=None, v=None, method='adapt', show=True):

--- a/src/spectrum/mtm.py
+++ b/src/spectrum/mtm.py
@@ -59,7 +59,7 @@ elif platform.system() == 'Darwin':
         # under python 3.X
         major = sys.version_info.major
         minor = sys.version_info.minor
-        lib_name = 'mydpss.cpython-{0}{1}m.so'.format(major, minor)
+        lib_name = 'mydpss.cpython-{0}{1}m-darwin.so'.format(major, minor)
         mtspeclib = ctypes.cdll.LoadLibrary(pj(p, lib_name))
 else:
     try:

--- a/src/spectrum/mtm.py
+++ b/src/spectrum/mtm.py
@@ -44,7 +44,7 @@ Note that on OSX -shared should be replaced by -dynamiclib and sum.so should be 
 p = os.path.abspath(os.path.dirname(__file__))
 lib_name = 'mydpss'
 try:
-    mtspeclib = load_library(libname, p)
+    mtspeclib = load_library(lib_name, p)
 except:
     print("Library %s not found" % lib_name)
 
@@ -359,7 +359,7 @@ def _autocov(s, **kwargs):
     debias = kwargs.pop('debias', True)
     axis = kwargs.get('axis', -1)
     if debias:
-        s = remove_bias(s, axis)
+        s = _remove_bias(s, axis)
     kwargs['debias'] = False
     return _crosscov(s, s, **kwargs)
 


### PR DESCRIPTION
Using OSX El Capitan and Anaconda Python 3.5 the library is called `mydpss.cpython-35m-darwin.so` not `mydpss.cpython-35m.so`.

*Update*
Use numpy helper function `load_library` to load library without having to build the library name manually.