### PR TITLE
allow freezeing mtspec library

### DIFF
--- a/src/spectrum/mtm.py
+++ b/src/spectrum/mtm.py
@@ -39,7 +39,13 @@ Note that on OSX -shared should be replaced by -dynamiclib and sum.so should be 
 
 """
 
-p = os.path.abspath(os.path.dirname(__file__))
+print(sys.executable)
+print(os.path.dirname(__file__))
+if hasattr(sys, 'frozen'):
+	p = os.path.abspath(os.path.dirname(sys.executable))
+else:
+	p = os.path.abspath(os.path.dirname(__file__))
+
 # Import shared mtspec library depending on the platform.
 if platform.system() == 'Windows':
     try:


### PR DESCRIPTION
Allow loading the shared library for frozen projects. Tested with py2exe.