### PR TITLE
return complex spectra from mtm.py for dual frequency analysis

### DIFF
--- a/src/spectrum/mtm.py
+++ b/src/spectrum/mtm.py
@@ -114,6 +114,9 @@ def pmtm(x, NW=None, k=None, NFFT=None, e=None, v=None, method='adapt', show=Tru
         res = pmtm(data, NW=2.5, show=False)
         res = pmtm(data, NW=2.5, k=4, show=True)
 
+
+    APN: modify method to return each Sk as complex values, the eigenvalues and the weights
+
     """
     assert method in ['adapt','eigen','unity']
 
@@ -134,7 +137,12 @@ def pmtm(x, NW=None, k=None, NFFT=None, e=None, v=None, method='adapt', show=Tru
 
     # set the NFFT
     if NFFT==None:
-        NFFT = max(256, 2**nextpow2(N))
+        NFFT = max(256, 2**nextpow2(N)) 
+        
+
+    Sk_complex = np.fft.fft(np.multiply(tapers.transpose(), x), NFFT)
+    Sk = abs(Sk_complex)**2
+
     # si nfft smaller thqn N, cut otherwise add wero.
     # compute 
     if method in ['eigen', 'unity']:
@@ -145,8 +153,8 @@ def pmtm(x, NW=None, k=None, NFFT=None, e=None, v=None, method='adapt', show=Tru
             weights = np.array([_x/float(i+1) for i,_x in enumerate(eigenvalues)])
             weights = weights.reshape(nwin,1)
 
-        Sk = abs(np.fft.fft(np.multiply(tapers.transpose(), x), NFFT))**2
-        Sk = np.mean(Sk * weights, axis=0)
+        #Sk = abs(np.fft.fft(np.multiply(tapers.transpose(), x), NFFT))**2
+        #Sk = np.mean(Sk * weights, axis=0)
 
 
     elif method == 'adapt':
@@ -180,11 +188,11 @@ def pmtm(x, NW=None, k=None, NFFT=None, e=None, v=None, method='adapt', show=Tru
             Stemp = S1
             S1 = S
             S = Stemp   # swap S and S1
-        Sk = S
-    #clf(); p.plot(); plot(arange(0,0.5,1./512),20*log10(res[0:256]))
-    if show==True:
-        semilogy(Sk)
-    return Sk
+        #Sk = S
+        
+        weights=wk
+
+    return Sk_complex,weights,eigenvalues
 
 
 


### PR DESCRIPTION
I made some changes to mtm.py to allow the complex spectral estimates to be returned so that dual frequency analysis could be performed. 

As is, the output is not terribly suitable for the way your library works, but could be modified for better integration. If you have some interest in making these types of changes I could clean them up better. 

I also have a dual frequency analysis tool that could be added, included below:

def cross_spectrum(sig1,sig2):
    """"
    sig1=list(Sk_complex,weights,eigenvalues)
    sig2=list(Sk_complex,weights,eigenvalues)
    
    Sk_complex.shape  = (Neigen,Nfft)
    weights.shape     = (Neigen,Nfft)
    eigenvalues.shape = (Neigen,)

    """
    # indices for unpacking
    specIdx = 0
    wtIdx   = 1
    eigIdx  = 2
    
    # unpack to simpler variables
    sk1  = sig1[specIdx]
    wt1  = sig1[wtIdx]
    eig1 = sig1[eigIdx]
    Ntapers1,Nfft1 = sk1.shape

    sk2  = sig2[specIdx]
    wt2  = sig2[wtIdx]
    eig2 = sig2[eigIdx]
    Ntapers2,Nfft2 = sk2.shape

    # check that sig1 and sig2 used the same number of tapers
    if not np.all(eig1==eig2):
        raise ValueError,'sig1 and sig2 should use the same number of tapers'

    if not Nfft1==Nfft2:
        raise ValueError,'sig1 and sig2 should have the same fft length' 

    #eigenvalues = sig1[eigIdx]
    #SK = 0 # index of spectral estimates in sig1/sig2
    #wk = 1 # index of the weights in sig1/sig2

    # now things that should be the same are set to a common variable name
    Ntapers,Nfft,eig = Ntapers1,Nfft1,eig1
    
    A = np.sum(1.0/eig) # sum of eigen value inverse eqn. 3
    
    # intialize
    numer = np.zeros(Nfft,dtype=sk1.dtype)
    #demon = np.zeros(len(sig1[0]))

    for i,e in enumerate(eig):
        numer += e * (wt1[i] * np.conj(sk1[i])) *  \
                     (wt2[i] *         sk2[i])
    #embed()
    denom = np.sqrt( np.sum(wt1**2,axis=specIdx) * \
                     np.sum(wt2**2,axis=specIdx))
    
    Sij = A/Ntapers * numer / denom

    return Sij

def coherence(sig1,sig2):
    return np.abs(cross_spectrum(sig1,sig2))**2/\
           cross_spectrum(sig1,sig1)/\
           cross_spectrum(sig2,sig2)

def dual_freq_cross_spectrum(sig1,sig2):
    """"
    sig1=list(Sk_complex,weights,eigenvalues)
    sig2=list(Sk_complex,weights,eigenvalues)
    
    Sk_complex.shape  = (Neigen,Nfft)
    weights.shape     = (Neigen,Nfft)
    eigenvalues.shape = (Neigen,)

    """
    # indices for unpacking
    specIdx = 0
    wtIdx   = 1
    eigIdx  = 2
    
    # unpack to simpler variables
    sk1  = sig1[specIdx]
    wt1  = sig1[wtIdx]
    eig1 = sig1[eigIdx]
    Ntapers1,Nfft1 = sk1.shape

    sk2  = sig2[specIdx]
    wt2  = sig2[wtIdx]
    eig2 = sig2[eigIdx]
    Ntapers2,Nfft2 = sk2.shape    

    # check that sig1 and sig2 used the same number of tapers
    if not np.all(eig1==eig2):
        raise ValueError,'sig1 and sig2 should use the same number of tapers'

    if not Nfft1==Nfft2:
        raise ValueError,'sig1 and sig2 should have the same fft length' 
 
    # now things that should be the same are set to a common variable name
    Ntapers,Nfft,eig = Ntapers1,Nfft1,eig1

    A = np.sum(1.0/eig) # sum of eigen value inverse eqn. 3

    # initialize 
    sij = np.zeros([Nfft,Nfft],dtype=sk1.dtype)

    #debug_here()
    
    for i,e in enumerate(eig):
        sij += e * np.outer( (wt1[i] * np.conj(sk1[i])),\
                             (wt2[i] *         sk2[i]))

    # was this:
    #sij /= np.sqrt( np.sum(wt1**2) + np.sum(wt2**2))
    # now this: don't understand results.
    sij /= np.sqrt( np.outer( np.sum(wt1**2,axis=0), \
                              np.sum(wt2**2,axis=0) ))
    sij *= A/Ntapers

    return sij

def dual_freq_coherence(sig1,sig2):
    return np.abs(dual_freq_cross_spectrum(sig1,sig2))**2/\
           np.outer(cross_spectrum(sig1,sig1),cross_spectrum(sig2,sig2))

def dual_freq_coherence_cplx(sig1,sig2):
    return dual_freq_cross_spectrum(sig1,sig2)**2/\
           np.outer(cross_spectrum(sig1,sig1),cross_spectrum(sig2,sig2))
 
