### PR TITLE
added cast to integer for fsize in fft. 

### DIFF
--- a/src/spectrum/mtm.py
+++ b/src/spectrum/mtm.py
@@ -497,7 +497,7 @@ def _fftconvolve(in1, in2, mode="full", axis=None):
         fslice = tuple(fslice)
 
     # Always use 2**n-sized FFT
-    fsize = 2**np.ceil(np.log2(size))
+    fsize = (2**np.ceil(np.log2(size))).astype(np.int64)
     if axis is None:
         IN1 = fftn(in1,fsize)
         IN1 *= fftn(in2,fsize)


### PR DESCRIPTION
numpy requires an integer type for the fft size. I'm using python 2.7.13 and numpy 1.12.0.

mtm.py uses a next power of two approach to compute the fft size. The function call returns a floating point and numpy raises a TypeError: 'numpy.float64' object cannot be interpreted as an index. This is a new feature of numpy as of version 1.12, to fail on indexing with floating point numbers.