### PR TITLE
changed output of dpss to be a list vice tuple.

### DIFF
--- a/src/spectrum/mtm.py
+++ b/src/spectrum/mtm.py
@@ -303,7 +303,7 @@ def dpss(N, NW=None, k=None):
     eigvals = dot(acvs, r)
 
     #return (tapers, lam)
-    return (tapers, eigvals)
+    return [tapers, eigvals]
 
 
 


### PR DESCRIPTION
A list is mutable so the taper normalization can be changed in place without copying the tapers. I wanted to be able to adjust the normalization in place to match another normalization I was using. Instead of creating a copy I suggest this change.  