### PR TITLE
Made matplotlib+pylab dependencies optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,10 @@ setup(
     package_dir={ '' : 'src' },
 
     # Dependencies
-    install_requires = ['matplotlib', 'numpy', 'scipy', 'easydev'],
+    install_requires=['numpy', 'scipy', 'easydev'],
+    extras_require={
+        'plot': ['matplotlib']
+    },
     data_files = data_files,
     platforms=["Linux"],
     classifiers=["Development Status :: 1 - Planning",

--- a/src/spectrum/correlation.py
+++ b/src/spectrum/correlation.py
@@ -22,10 +22,18 @@
 """#from numpy.fft import fft, ifft
 import numpy
 from numpy import  arange, isrealobj
-from pylab import rms_flat
+# from pylab import rms_flat
 
 
 __all__ = ['CORRELATION', 'xcorr']
+
+
+def pylab_rms_flat(a):
+    """
+    Return the root mean square of all the elements of *a*, flattened out.
+    (Copied 1:1 from matplotlib.mlab.)
+    """
+    return numpy.sqrt(numpy.mean(numpy.absolute(a) ** 2))
 
 
 def CORRELATION(x, y=None, maxlags=None, norm='unbiased'):
@@ -104,8 +112,8 @@ def CORRELATION(x, y=None, maxlags=None, norm='unbiased'):
         r = numpy.zeros(maxlags, dtype=complex)
 
     if norm == 'coeff':
-        rmsx = rms_flat(x)
-        rmsy = rms_flat(y)
+        rmsx = pylab_rms_flat(x)
+        rmsy = pylab_rms_flat(y)
 
     for k in range(0, maxlags+1):
         nk = N - k - 1
@@ -208,7 +216,7 @@ def xcorr(x, y=None, maxlags=None, norm='biased'):
         res = res[lags] / (float(N)-abs(arange(-N+1, N)))[lags]
     elif norm == 'coeff':
         Nf = float(N)
-        rms = rms_flat(x) * rms_flat(y)
+        rms = pylab_rms_flat(x) * pylab_rms_flat(y)
         res = res[lags] / rms / Nf
     else:
         res = res[lags]

--- a/src/spectrum/datasets.py
+++ b/src/spectrum/datasets.py
@@ -12,7 +12,6 @@
  
     :Reference: [Marple]_
 """
-from  pylab import plot, linspace, xlabel, ylabel, grid
 import numpy
 from numpy import arange, pi, cos
 
@@ -150,14 +149,9 @@ class TimeSeries():
     def plot(self, **kargs):
         """Plot the data set, using the sampling information to set the x-axis 
         correctly."""
+        from pylab import plot, linspace, xlabel, ylabel, grid
         time = linspace(1*self.dt, self.N*self.dt, self.N)
         plot(time, self.data, **kargs)
         xlabel('Time')
         ylabel('Amplitude')
         grid(True)
-
-
-
-
-
-

--- a/src/spectrum/mtm.py
+++ b/src/spectrum/mtm.py
@@ -20,7 +20,6 @@ from ctypes import POINTER
 import os
 from os.path import join as pj
 from spectrum.tools import nextpow2
-from pylab import semilogy
 from numpy.ctypeslib import load_library
 
 """
@@ -53,7 +52,7 @@ except:
     print("Library %s not found" % lib_name)
 
 
-def pmtm(x, NW=None, k=None, NFFT=None, e=None, v=None, method='adapt', show=True):
+def pmtm(x, NW=None, k=None, NFFT=None, e=None, v=None, method='adapt', show=False):
     """Multitapering spectral estimation
 
     :param array x: the data
@@ -173,6 +172,7 @@ def pmtm(x, NW=None, k=None, NFFT=None, e=None, v=None, method='adapt', show=Tru
         weights=wk
 
     if show is True:
+        from pylab import semilogy
         if method == "adapt":
             Sk = np.mean(Sk * weights, axis=1)
         else:

--- a/src/spectrum/periodogram.py
+++ b/src/spectrum/periodogram.py
@@ -39,10 +39,9 @@ the computation. For instance, if you can change the output easily::
 """
 from .window import Window
 from .psd import Spectrum, FourierSpectrum
-from pylab import pi, fft, mean, rfft
-from numpy import array, ceil
+from numpy import array, ceil, pi, mean, linspace
+from numpy.fft import fft, rfft
 import numpy
-import pylab as plt
 
 
 
@@ -191,9 +190,10 @@ def WelchPeriodogram(data, NFFT=None,  sampling=1., **kargs):
 
 
     """
+    from pylab import psd
     spectrum = Spectrum(data, sampling=1.)
 
-    P = plt.psd(data, NFFT, Fs=sampling, **kargs)
+    P = psd(data, NFFT, Fs=sampling, **kargs)
     spectrum.psd = P[0]
     #spectrum.__Spectrum_sides = 'twosided'
 
@@ -305,10 +305,10 @@ def DaniellPeriodogram(data, P, NFFT=None, detrend='mean', sampling=1.,
 
     #todo: check this
     if datatype == 'complex':
-        freq = plt.linspace(0,sampling, len(newpsd))
+        freq = linspace(0,sampling, len(newpsd))
     else:
         df = 1./sampling
-        freq = plt.linspace(0,sampling/2., len(newpsd))
+        freq = linspace(0,sampling/2., len(newpsd))
     #psd.refreq(2*psd.size()/A.freq());
     #psd.retime(-1./psd.freq()+1./A.size());
 

--- a/src/spectrum/psd.py
+++ b/src/spectrum/psd.py
@@ -1,6 +1,4 @@
 """This module provides the Base class for PSDs"""
-import pylab as plt
-import pylab
 import numpy
 
 from spectrum.tools import nextpow2
@@ -521,7 +519,7 @@ class Spectrum(object):
 
     def scale(self):
         if self.scale_by_freq is True:
-            self.psd *= 2*plt.pi/self.df
+            self.psd *= 2*numpy.pi/self.df
 
     def frequencies(self, sides=None):
 
@@ -632,6 +630,7 @@ class Spectrum(object):
             p.plot(norm=True, marker='o')
 
         """
+        import pylab
         #First, check that psd attribute is up-to-date
         if self.modified is True:
             raise errors.SpectrumModifiedError
@@ -667,8 +666,8 @@ class Spectrum(object):
         from pylab import ylim as plt_ylim
 
         if 'ax' in list(kargs.keys()):
-            save_ax = plt.gca()
-            plt.sca(kargs['ax'])
+            save_ax = pylab.gca()
+            pylab.sca(kargs['ax'])
             rollback = True
             del kargs['ax']
         else:
@@ -679,8 +678,8 @@ class Spectrum(object):
         else:
             pylab.plot(frequencies, 10*pylab.log10(psd),**kargs)
 
-        plt.xlabel('Frequency')
-        plt.ylabel('Power (dB)')
+        pylab.xlabel('Frequency')
+        pylab.ylabel('Power (dB)')
         pylab.grid(True)
         if ylim:
             plt_ylim(ylim)
@@ -693,7 +692,7 @@ class Spectrum(object):
         if filename:
             pylab.savefig(filename)
         if rollback:
-            plt.sca(save_ax)
+            pylab.sca(save_ax)
         del psd, frequencies #is it needed?
 
     def power(self):
@@ -714,7 +713,7 @@ class Spectrum(object):
         if self.scale_by_freq == False:
             return sum(self.psd) * len(self.psd)
         else:
-            return sum(self.psd) * self.df/(2.*plt.pi)
+            return sum(self.psd) * self.df/(2.*numpy.pi)
 
     def _str_title(self):
         return "Spectrum summary\n"

--- a/src/spectrum/window.py
+++ b/src/spectrum/window.py
@@ -199,7 +199,8 @@ class Window(object):
 
 
         """
-        from pylab import fft, fftshift, log10
+        from numpy import log10
+        from numpy.fft import fft, fftshift
 
         norm = kargs.get('norm', self.norm)
 


### PR DESCRIPTION
# Motivation
Since the matplotlib/pylab dependency pulls in graphical dependencies such as Tk, Qt, etc. which are not desirable on a headless server environment (with regards to scaling issues).

# Changes
To reach optional dependency on matplotlib/pylab, the following changes were made:
- In setup.py the matplotlib dependency was moved from _required_ to _optional_.
- Most pylab functions are mere shortcuts to actual functions of the numpy library. Those dependencies were replaced by their respective numpy replacements.
- Plotting functions that really need matplotlib functionality now have these respective imports directly in their function's body. Thus, the matplotlib is only required, if one (or more) of these functions is called.
- None of the changes made produces any semantic change of the library, except for one thing: `pmtm()`'s show parameter's default value was changed from `True` to `False`.