### PR TITLE
Add travis badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,9 +9,13 @@ SPECTRUM : Spectral Analysis in Python
 
 .. image:: https://coveralls.io/repos/cokelaer/spectrum/badge.png?branch=master 
     :target: https://coveralls.io/r/cokelaer/spectrum?branch=master 
-
+    
+.. image:: https://travis-ci.org/cokelaer/spectrum.svg?branch=master
+    :target: https://travis-ci.org/cokelaer/spectrum
+    
 .. image:: https://landscape.io/github/cokelaer/spectrum/master/landscape.png
     :target: https://landscape.io/github/cokelaer/spectrum/master
+
 
 
 


### PR DESCRIPTION
While doing openjournals/joss-reviews#348, I noticed it was a bit hard to find the travis builds. This PR just adds a travis badge to make this simpler.  Not mandatory for the review or anything, but I thought this might be helpful.