### PR TITLE
Add `return self` to end of __call__ methods to allow method chaining

### DIFF
--- a/src/spectrum/arma.py
+++ b/src/spectrum/arma.py
@@ -275,6 +275,7 @@ class parma(ParametricSpectrum):
             self.psd = psd
         if self.scale_by_freq is True:
             self.scale()
+        return self
 
     def _str_title(self):
         return "ARMA PSD estimate\n"

--- a/src/spectrum/burg.py
+++ b/src/spectrum/burg.py
@@ -150,6 +150,7 @@ class pburg(ParametricSpectrum):
         else:
             self.psd = psd
         self.scale()
+        return self
 
     def _str_title(self):
         return "Periodogram PSD estimate\n"

--- a/src/spectrum/correlog.py
+++ b/src/spectrum/correlog.py
@@ -197,6 +197,7 @@ class pcorrelogram(FourierSpectrum):
         else:
             self.psd = psd
         self.scale()
+        return self
 
     def _str_title(self):
         return "Correlogram PSD estimate\n"

--- a/src/spectrum/covar.py
+++ b/src/spectrum/covar.py
@@ -376,6 +376,7 @@ class pcovar(ParametricSpectrum):
             self.psd = psd
         if self.scale_by_freq is True:
             self.scale()
+        return self
 
     def _str_title(self):
         return "Covariance PSD estimate\n"

--- a/src/spectrum/criteria.py
+++ b/src/spectrum/criteria.py
@@ -128,7 +128,7 @@ class Criteria(object):
     rho = property(fget=_getRho, fset=_setRho, doc="Getter/Setter for rho")
 
     def __call__(self, rho=None, k=None, N=None, norm=True):
-        """Call the criteria function correspondign to :attr:`name`."""
+        """Call the criteria function corresponding to :attr:`name`."""
         self.__norm = norm
         if N is not None:
             self.N = N

--- a/src/spectrum/eigenfre.py
+++ b/src/spectrum/eigenfre.py
@@ -73,6 +73,7 @@ class pmusic(ParametricSpectrum):
             self.psd = centerdc_2_twosided(psd)
 
         self.scale()
+        return self
 
     def _str_title(self):
         return "Music PSD estimate\n"
@@ -135,6 +136,7 @@ class pev(ParametricSpectrum):
             self.psd = centerdc_2_twosided(psd)
 
         self.scale()
+        return self
 
     def _str_title(self):
         return "EV PSD estimate\n"

--- a/src/spectrum/modcovar.py
+++ b/src/spectrum/modcovar.py
@@ -322,6 +322,7 @@ class pmodcovar(ParametricSpectrum):
             self.psd = psd
         if self.scale_by_freq is True:
             self.scale()
+        return self
 
     def _str_title(self):
         return "Modified covariance PSD estimate\n"

--- a/src/spectrum/mtm.py
+++ b/src/spectrum/mtm.py
@@ -93,6 +93,7 @@ class MultiTapering(Spectrum):
             self.psd = newpsd
         else:
             self.psd = self.Sk
+        return self
 
     def __str_title(self):
         return "Multitapering estimate\n"

--- a/src/spectrum/periodogram.py
+++ b/src/spectrum/periodogram.py
@@ -248,6 +248,7 @@ class Periodogram(FourierSpectrum):
         self.psd = psd
         if self.scale_by_freq is True:
             self.scale()
+        return self
 
     def _str_title(self):
         return "Periodogram PSD estimate\n"
@@ -361,6 +362,7 @@ class pdaniell(FourierSpectrum):
                   scale_by_freq=self.scale_by_freq,
                   detrend=self.detrend)
         self.psd = res[0]
+        return self
 
     def _str_title(self):
         return "Daniell Periodogram PSD estimate\n"

--- a/src/spectrum/yulewalker.py
+++ b/src/spectrum/yulewalker.py
@@ -170,6 +170,7 @@ class pyule(ParametricSpectrum):
             self.psd = psd
         if self.scale_by_freq is True:
             self.scale()
+        return self
 
     def _str_title(self):
         return "PYule PSD estimate\n"


### PR DESCRIPTION
It would be advantageous for `__call__` methods to return themselves to allow for method chaining. This would allow for clean inline implementations of the classes (e.g. using [list comprehension](https://gist.github.com/sambnh/3139fb2c9edfc84c5d3b41c8323d71f1))