### PR TITLE
eigen-speed-up

### DIFF
--- a/src/spectrum/eigenfre.py
+++ b/src/spectrum/eigenfre.py
@@ -265,8 +265,8 @@ def eigen(X, P, NSIG=None, method='music', threshold=None, NFFT=default_NFFT,
     #     for K in range(0, P):
     #         FB[I, K] = X[I-K+P-1]
     #         FB[I+NP, K] = X[I+K+1].conjugate()
-    FB[:NP, :] = linalg.toeplitz(X[P - 1 : -1], X[P - 1 :: -1])
-    FB[NP:, :] = linalg.hankel(X[1 : -P + 1].conjugate(), X[-P:].conjugate())
+    FB[:NP, :] = linalg.toeplitz(X[P - 1 : NP+P-1], X[P - 1 :: -1])
+    FB[NP:, :] = linalg.hankel(X[1 : -P + 1].conjugate(), X[-P:NP+P].conjugate())
 
 
     # This commented line produces the correct FB, as the 2 for loops above

--- a/src/spectrum/eigenfre.py
+++ b/src/spectrum/eigenfre.py
@@ -7,7 +7,7 @@ from numpy.linalg import svd
 from spectrum import default_NFFT
 from .psd import ParametricSpectrum
 from .tools import twosided_2_onesided, centerdc_2_twosided, twosided_2_centerdc
-
+from scipy import linalg 
 
 __all__ = ["music", "ev", "pmusic", "eigen", "pev"]
 
@@ -261,10 +261,13 @@ def eigen(X, P, NSIG=None, method='music', threshold=None, NFFT=default_NFFT,
     PSD = np.zeros(NFFT)
 
     # These loops can surely be replaced by a function that create such matrix
-    for I in range(0, NP):
-        for K in range(0, P):
-            FB[I, K] = X[I-K+P-1]
-            FB[I+NP, K] = X[I+K+1].conjugate()
+    # for I in range(0, NP):
+    #     for K in range(0, P):
+    #         FB[I, K] = X[I-K+P-1]
+    #         FB[I+NP, K] = X[I+K+1].conjugate()
+    FB[:NP, :] = linalg.toeplitz(X[P - 1 : -1], X[P - 1 :: -1])
+    FB[NP:, :] = linalg.hankel(X[1 : -P + 1].conjugate(), X[-P:].conjugate())
+
 
     # This commented line produces the correct FB, as the 2 for loops above
     # It is more elegant but slower...corrmtx needs to be optimised (20/4/11)


### PR DESCRIPTION
Hi, 

First, very nice package, thank you for sharing.

Now, I've noticed that you have a comment in `eigenfre.py`:

>    These loops can surely be replaced by a function that create such matrix
>    ...
>    This commented line produces the correct FB, as the 2 for loops above
>    It is more elegant but slower...corrmtx needs to be optimised (20/4/11)

This is a PR to address it using scipy's `toeplitz` and `hankel` functions in its `linalg`

Unfortunately, I have not figured out how to build & test this repo, so I haven't run test on it. However, here is my little code snippet to test the speed:

```
import timeit
import numpy as np
from scipy import linalg

P = 4
N = 100
NP = N - P
X = np.random.randn(N)


def f():
    FB = np.zeros((2 * NP, P), dtype=complex)
    for I in range(0, NP):
        for K in range(0, P):
            FB[I, K] = X[I - K + P - 1]
            FB[I + NP, K] = X[I + K + 1].conjugate()
    return FB


def g():
    FB = np.empty((2 * NP, P))
    FB[:NP, :] = linalg.toeplitz(X[P - 1 : -1], X[P - 1 :: -1])
    FB[NP:, :] = linalg.hankel(X[1 : -P + 1].conjugate(), X[-P:].conjugate())
    return FB

print("f()==g()?", np.allclose(f(),g()))

print(
    (
        timeit.timeit(stmt="f()", number=10000, globals=globals()),
        timeit.timeit(stmt="g()", number=10000, globals=globals()),
    )
)
```

and got:

```
f()==g()? True
(3.4352105, 0.2035477000000001)
```

So there is a sizable performance improvement with proper output.