### PR TITLE
Use scipy.signal.correlate for efficiency

### DIFF
--- a/src/spectrum/correlation.py
+++ b/src/spectrum/correlation.py
@@ -21,6 +21,7 @@
 
 """
 import numpy as np
+import scipy.signal
 
 
 __all__ = ['CORRELATION', 'xcorr']
@@ -208,7 +209,7 @@ def xcorr(x, y=None, maxlags=None, norm='biased'):
         assert maxlags <= N, 'maxlags must be less than data length'
         lags = np.arange(N-maxlags-1, N+maxlags)
 
-    res = np.correlate(x, y, mode='full')
+    res = scipy.signal.correlate(x, y, mode='full')
 
     if norm == 'biased':
         Nf = float(N)


### PR DESCRIPTION
The scipy.signal.correlate function will use a FFT (when it makes sense to) to compute the cross correlation more efficiently than numpy.correlate.