### PR TITLE
Fix rho calculation and complex number handling in arburg2 algorithm

### DIFF
--- a/src/spectrum/burg.py
+++ b/src/spectrum/burg.py
@@ -52,7 +52,7 @@ def _arburg2(X, order):
 
     temp = 1.
     E = np.zeros(order+1)
-    E[0] = rho
+    E[0] = rho.copy()
 
     for m in range(0, order):
         #print m
@@ -74,7 +74,7 @@ def _arburg2(X, order):
         a = a + ref[m] * np.flipud(a).conjugate()
 
         # Update the prediction error
-        E[m+1] = (1 - ref[m].conj().transpose()*ref[m]) * E[m]
+        E[m+1] = (1 - ref[m].conj().transpose()*ref[m]).real * E[m]
         #print 'REF', ref, num, den
     return a, E[-1], ref
 


### PR DESCRIPTION
This commit addresses two key issues in the Burg algorithm implementation. First, it corrects the calculation of rho to maintain its initial value throughout the algorithm, ensuring it accurately represents the total power of the input signal. Second, it resolves a ComplexWarning by explicitly using the real part of complex calculations, aligning with the expected behavior of the algorithm for real-valued signals.